### PR TITLE
Lynxchan v2 support and fixes for v1

### DIFF
--- a/src/nya/miku/wishmaster/api/AbstractLynxChanModule.java
+++ b/src/nya/miku/wishmaster/api/AbstractLynxChanModule.java
@@ -508,6 +508,20 @@ public abstract class AbstractLynxChanModule extends AbstractWakabaModule {
         return md5Hex;
     }
 
+    protected boolean checkFileIdentifier(String hash, String mime, ProgressListener listener, CancellableTask task) {
+        if (hash == null || mime == null) return false;
+        String identifier = hash + "-" + mime.replace("/", "");
+        String url = getUsingUrl() + "checkFileIdentifier.js?json=1&identifier=" + identifier;
+        String response;
+        try {
+            response = HttpStreamer.getInstance().getStringFromUrl(url, null, httpClient, listener, task, false);
+            return response.contains("true");
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
     public class ExtendedCaptchaModel extends CaptchaModel {
         public String captchaID = "";
     }

--- a/src/nya/miku/wishmaster/api/AbstractLynxChanModule.java
+++ b/src/nya/miku/wishmaster/api/AbstractLynxChanModule.java
@@ -492,7 +492,7 @@ public abstract class AbstractLynxChanModule extends AbstractWakabaModule {
     }
 
     @Override
-    public CaptchaModel getNewCaptcha(String boardName, String threadNumber, ProgressListener listener, CancellableTask task) throws Exception {
+    public ExtendedCaptchaModel getNewCaptcha(String boardName, String threadNumber, ProgressListener listener, CancellableTask task) throws Exception {
         String captchaUrl = getUsingUrl() + "captcha.js?d=" + Math.random();
         return downloadCaptcha(captchaUrl, listener, task);
     }

--- a/src/nya/miku/wishmaster/api/AbstractLynxChanModule.java
+++ b/src/nya/miku/wishmaster/api/AbstractLynxChanModule.java
@@ -23,7 +23,6 @@ import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -52,9 +51,7 @@ import nya.miku.wishmaster.api.models.AttachmentModel;
 import nya.miku.wishmaster.api.models.BadgeIconModel;
 import nya.miku.wishmaster.api.models.BoardModel;
 import nya.miku.wishmaster.api.models.CaptchaModel;
-import nya.miku.wishmaster.api.models.DeletePostModel;
 import nya.miku.wishmaster.api.models.PostModel;
-import nya.miku.wishmaster.api.models.SendPostModel;
 import nya.miku.wishmaster.api.models.SimpleBoardModel;
 import nya.miku.wishmaster.api.models.ThreadModel;
 import nya.miku.wishmaster.api.models.UrlPageModel;
@@ -63,16 +60,10 @@ import nya.miku.wishmaster.api.util.CryptoUtils;
 import nya.miku.wishmaster.api.util.RegexUtils;
 import nya.miku.wishmaster.api.util.UrlPathUtils;
 import nya.miku.wishmaster.api.util.WakabaUtils;
-import nya.miku.wishmaster.common.IOUtils;
 import nya.miku.wishmaster.common.Logger;
-import nya.miku.wishmaster.http.JSONEntry;
-import nya.miku.wishmaster.http.interactive.SimpleCaptchaException;
 import nya.miku.wishmaster.http.streamer.HttpRequestModel;
 import nya.miku.wishmaster.http.streamer.HttpResponseModel;
 import nya.miku.wishmaster.http.streamer.HttpStreamer;
-import nya.miku.wishmaster.lib.MimeTypes;
-import nya.miku.wishmaster.lib.base64.Base64;
-import nya.miku.wishmaster.lib.base64.Base64OutputStream;
 import nya.miku.wishmaster.lib.org_json.JSONArray;
 import nya.miku.wishmaster.lib.org_json.JSONObject;
 
@@ -89,9 +80,7 @@ public abstract class AbstractLynxChanModule extends AbstractWakabaModule {
     private static final Pattern GREEN_TEXT_MARK_PATTERN = Pattern.compile("<span class=\"greenText\">(.*?)</span>");
     private static final Pattern REPLY_NUMBER_PATTERN = Pattern.compile("&gt&gt(\\d+)");
     protected Map<String, BoardModel> boardsMap = null;
-    private Map<String, ArrayList<String>> flagsMap = null;
-    private static String lastCaptchaId;
-    private static String lastCaptchaAnswer;
+    protected Map<String, ArrayList<String>> flagsMap = null;
     
     public AbstractLynxChanModule(SharedPreferences preferences, Resources resources) {
         super(preferences, resources);
@@ -410,7 +399,7 @@ public abstract class AbstractLynxChanModule extends AbstractWakabaModule {
         return super.fixRelativeUrl(url);
     }
 
-    protected CaptchaModel downloadCaptcha(String captchaUrl, ProgressListener listener, CancellableTask task) throws Exception {
+    protected ExtendedCaptchaModel downloadCaptcha(String captchaUrl, ProgressListener listener, CancellableTask task) throws Exception {
         Bitmap captchaBitmap = null;
         HttpRequestModel requestModel = HttpRequestModel.DEFAULT_GET;
         HttpResponseModel responseModel = HttpStreamer.getInstance().getFromUrl(captchaUrl, requestModel, httpClient, listener, task);
@@ -433,10 +422,10 @@ public abstract class AbstractLynxChanModule extends AbstractWakabaModule {
         } finally {
             responseModel.release();
         }
-        CaptchaModel captchaModel = new CaptchaModel();
+        ExtendedCaptchaModel captchaModel = new ExtendedCaptchaModel();
         captchaModel.type = CaptchaModel.TYPE_NORMAL;
         captchaModel.bitmap = captchaBitmap;
-        lastCaptchaId = captchaId;
+        captchaModel.captchaID = captchaId;
         return captchaModel;
     }
 
@@ -446,7 +435,7 @@ public abstract class AbstractLynxChanModule extends AbstractWakabaModule {
         return downloadCaptcha(captchaUrl, listener, task);
     }
 
-    private String computeFileMD5(File file) throws NoSuchAlgorithmException, IOException {
+    public static String computeFileMD5(File file) throws NoSuchAlgorithmException, IOException {
         MessageDigest messageDigest = MessageDigest.getInstance("MD5");
         messageDigest.reset();
 
@@ -469,149 +458,7 @@ public abstract class AbstractLynxChanModule extends AbstractWakabaModule {
         return md5Hex;
     }
 
-    private String checkFileIdentifier(File file, String mime, ProgressListener listener, CancellableTask task) {
-        String hash;
-        try {
-            hash = computeFileMD5(file);
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
-        String identifier = hash + "-" + mime.replace("/", "");
-        String url = getUsingUrl() + "checkFileIdentifier.js?identifier=" + identifier;
-        String response = "";
-        try {
-            response = HttpStreamer.getInstance().getStringFromUrl(url, null, httpClient, listener, task, false);
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
-        if (response.contains("true")) return hash;
-        return null;
+    public class ExtendedCaptchaModel extends CaptchaModel {
+        public String captchaID = "";
     }
-
-    private String base64EncodeFile(File file) throws IOException {
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        Base64OutputStream b64os = new Base64OutputStream(os, Base64.NO_WRAP);
-        FileInputStream fis = new FileInputStream(file);
-        IOUtils.copyStream(fis, b64os);
-        return os.toString();
-    }
-
-    public String sendPost(SendPostModel model, ProgressListener listener, CancellableTask task) throws Exception {
-        String url = getUsingUrl() + ".api/" + (model.threadNumber == null ? "newThread" : "replyThread");
-
-        JSONObject jsonPayload = new JSONObject();
-        JSONObject jsonParameters = new JSONObject();
-        jsonPayload.put("captchaId", lastCaptchaId);
-        jsonParameters.put("name", model.name);
-        jsonParameters.put("password", model.password);
-        jsonParameters.put("subject", model.subject);
-        jsonParameters.put("message", model.comment);
-        jsonParameters.put("boardUri", model.boardName);
-        jsonParameters.put("email", model.sage ? "sage" : model.email);
-        if (model.threadNumber != null)
-            jsonParameters.put("threadId", model.threadNumber);
-        if (model.captchaAnswer != null && model.captchaAnswer.length() > 0)
-            jsonParameters.put("captcha", model.captchaAnswer);
-        if (model.icon > 0)
-            jsonParameters.put("flag", flagsMap.get(model.boardName).get(model.icon - 1));
-        if (model.attachments != null && model.attachments.length > 0) {
-            JSONArray files = new JSONArray();
-            for (int i = 0; i < model.attachments.length; ++i) {
-                String name = model.attachments[i].getName();
-                String mime = MimeTypes.forExtension(name.substring(name.lastIndexOf('.') + 1), "");
-                String md5 = checkFileIdentifier(model.attachments[i], mime, listener, task);
-                JSONObject file = new JSONObject();
-                file.put("name", name);
-                if (md5 != null) {
-                    file.put("md5", md5);
-                    file.put("mime", mime);
-                } else {
-                    file.put("content", "data:" + mime + ";base64," + base64EncodeFile(model.attachments[i]));
-                }
-                file.put("spoiler", false);
-                files.put(file);
-            }
-            jsonParameters.put("spoiler", model.custommark);
-            jsonParameters.put("files", files);
-        }
-        jsonPayload.put("parameters", jsonParameters);
-        JSONEntry payload = new JSONEntry(jsonPayload);
-        HttpRequestModel request = HttpRequestModel.builder().setPOST(payload).setNoRedirect(true).build();
-        String response = HttpStreamer.getInstance().getStringFromUrl(url, request, httpClient, null, task, true);
-        lastCaptchaId = null;
-        JSONObject result = new JSONObject(response);
-        String status = result.optString("status");
-        if ("ok".equals(status)) {
-            UrlPageModel urlPageModel = new UrlPageModel();
-            urlPageModel.type = UrlPageModel.TYPE_THREADPAGE;
-            urlPageModel.chanName = getChanName();
-            urlPageModel.boardName = model.boardName;
-            urlPageModel.threadNumber = model.threadNumber;
-            if (model.threadNumber == null) {
-                urlPageModel.threadNumber = Integer.toString(result.optInt("data"));
-            } else {
-                urlPageModel.postNumber = Integer.toString(result.optInt("data"));
-            }
-            return buildUrl(urlPageModel);
-        } else if (status.contains("error") || status.contains("blank")) {
-            String errorMessage = result.optString("data");
-            if (errorMessage.length() > 0) {
-                throw new Exception(errorMessage);
-            }
-        }
-        throw new Exception("Unknown Error");
-    }
-
-    @Override
-    public String deletePost(DeletePostModel model, final ProgressListener listener, final CancellableTask task) throws Exception {
-        String url = getUsingUrl() + ".api/" + "deleteContent";
-        
-        if (lastCaptchaAnswer == null) {
-            throw new SimpleCaptchaException() {
-                private static final long serialVersionUID = 1L;
-                @Override
-                protected Bitmap getNewCaptcha() throws Exception {
-                    return AbstractLynxChanModule.this.getNewCaptcha("", "", listener, task).bitmap;
-                }
-                @Override
-                protected void storeResponse(String response) {
-                    lastCaptchaAnswer = response;
-                }
-            };
-        }
-        
-        JSONObject jsonPayload = new JSONObject();
-        JSONObject jsonParameters = new JSONObject();
-        jsonPayload.put("captchaId", lastCaptchaId);
-        jsonParameters.put("password", model.password);
-        if (lastCaptchaAnswer != null && lastCaptchaAnswer.length() > 0)
-            jsonParameters.put("captcha", lastCaptchaAnswer);
-        jsonParameters.put("deleteMedia", true);
-        if (model.onlyFiles) {
-            jsonParameters.put("deleteUploads", true);
-        }
-        JSONArray jsonArray = new JSONArray();
-        JSONObject post = new JSONObject();
-        post.put("board", model.boardName);
-        post.put("thread", model.threadNumber);
-        if (!model.postNumber.equals(model.threadNumber)) post.put("post", model.postNumber);
-        jsonParameters.put("postings", jsonArray);
-        jsonPayload.put("parameters", jsonParameters);
-        JSONEntry payload = new JSONEntry(jsonPayload);
-        HttpRequestModel request = HttpRequestModel.builder().setPOST(payload).setNoRedirect(true).build();
-        String response = HttpStreamer.getInstance().getStringFromUrl(url, request, httpClient, null, task, true);
-        lastCaptchaId = null;
-        lastCaptchaAnswer = null;
-        JSONObject result = new JSONObject(response);
-        if (result.optString("status").equals("error")) {
-            String errorMessage = result.optString("data");
-            if (errorMessage.length() > 0) {
-                throw new Exception(errorMessage);
-            }
-        }
-        return null;
-    }
-    
 }

--- a/src/nya/miku/wishmaster/api/AbstractLynxChanModule.java
+++ b/src/nya/miku/wishmaster/api/AbstractLynxChanModule.java
@@ -22,7 +22,6 @@ import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.webkit.MimeTypeMap;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -71,6 +70,7 @@ import nya.miku.wishmaster.http.interactive.SimpleCaptchaException;
 import nya.miku.wishmaster.http.streamer.HttpRequestModel;
 import nya.miku.wishmaster.http.streamer.HttpResponseModel;
 import nya.miku.wishmaster.http.streamer.HttpStreamer;
+import nya.miku.wishmaster.lib.MimeTypes;
 import nya.miku.wishmaster.lib.base64.Base64;
 import nya.miku.wishmaster.lib.base64.Base64OutputStream;
 import nya.miku.wishmaster.lib.org_json.JSONArray;
@@ -516,24 +516,24 @@ public abstract class AbstractLynxChanModule extends AbstractWakabaModule {
             jsonParameters.put("captcha", model.captchaAnswer);
         if (model.icon > 0)
             jsonParameters.put("flag", flagsMap.get(model.boardName).get(model.icon - 1));
-        MimeTypeMap mimeTypeMap = MimeTypeMap.getSingleton();
         if (model.attachments != null && model.attachments.length > 0) {
             JSONArray files = new JSONArray();
             for (int i = 0; i < model.attachments.length; ++i) {
-                String ext = MimeTypeMap.getFileExtensionFromUrl(model.attachments[i].toURI().toString());
-                String mime = mimeTypeMap.getMimeTypeFromExtension(ext);
+                String name = model.attachments[i].getName();
+                String mime = MimeTypes.forExtension(name.substring(name.lastIndexOf('.') + 1), "");
                 String md5 = checkFileIdentifier(model.attachments[i], mime, listener, task);
                 JSONObject file = new JSONObject();
-                file.put("name", model.attachments[i].getName());
+                file.put("name", name);
                 if (md5 != null) {
                     file.put("md5", md5);
                     file.put("mime", mime);
                 } else {
                     file.put("content", "data:" + mime + ";base64," + base64EncodeFile(model.attachments[i]));
                 }
-                file.put("spoiler", model.custommark);
+                file.put("spoiler", false);
                 files.put(file);
             }
+            jsonParameters.put("spoiler", model.custommark);
             jsonParameters.put("files", files);
         }
         jsonPayload.put("parameters", jsonParameters);

--- a/src/nya/miku/wishmaster/api/AbstractLynxChanModule.java
+++ b/src/nya/miku/wishmaster/api/AbstractLynxChanModule.java
@@ -184,14 +184,14 @@ public abstract class AbstractLynxChanModule extends AbstractWakabaModule {
             } catch (Exception e) {
                 boardJson = new JSONObject();
             }
-            BoardModel model = mapBoardModel(boardJson);
+            BoardModel model = mapBoardModel(boardJson, shortName);
             boardsMap.put(model.boardName, model);
             return model;
         }
     }
 
-    protected BoardModel mapBoardModel(JSONObject json) {
-        BoardModel model = getDefaultBoardModel(json.getString("boardUri"));
+    protected BoardModel mapBoardModel(JSONObject json, String shortName) {
+        BoardModel model = getDefaultBoardModel(shortName);
         model.boardDescription = json.optString("boardName", model.boardName);
         model.attachmentsMaxCount = json.optInt("maxFileCount", 5);
         model.lastPage = json.optInt("pageCount", BoardModel.LAST_PAGE_UNDEFINED);
@@ -273,9 +273,9 @@ public abstract class AbstractLynxChanModule extends AbstractWakabaModule {
         JSONObject response = downloadJSONObject(url, oldList != null, listener, task);
         if (response == null) return oldList;
         try {
-            BoardModel board = mapBoardModel(response);
+            BoardModel board = mapBoardModel(response, boardName);
             if (boardsMap == null) boardsMap = new HashMap<>();
-            boardsMap.put(board.boardName, board);
+            boardsMap.put(boardName, board);
         } catch (Exception e) {}
         JSONArray threads = response.getJSONArray("threads");
         ThreadModel[] result = new ThreadModel[threads.length()];
@@ -347,8 +347,8 @@ public abstract class AbstractLynxChanModule extends AbstractWakabaModule {
                 String ext = MimeTypes.toExtension(mime);
                 attachment.path = thumb.replace("t_", "")
                         + (ext != null ? "." + ext : "");
-            } else {
-                attachment.thumbnail = fixRelativeUrl(attachment.thumbnail);
+            } else { //Internal image (e.g. spoiler)
+                attachment.thumbnail = fixRelativeUrl(thumb); //fix equal hashes in cache
                 attachment.path = attachment.thumbnail;
             }
             attachment.height = -1;

--- a/src/nya/miku/wishmaster/chans/endchan/EndChanModule.java
+++ b/src/nya/miku/wishmaster/chans/endchan/EndChanModule.java
@@ -62,6 +62,11 @@ import nya.miku.wishmaster.lib.org_json.JSONArray;
 import nya.miku.wishmaster.lib.org_json.JSONException;
 import nya.miku.wishmaster.lib.org_json.JSONObject;
 
+/**
+ * Class interacting with Endchan imageboard (Lynxchan engine version 1)
+ * Can be used as a superclass for modules of sites using the same version of the engine.
+ */
+
 public class EndChanModule extends AbstractLynxChanModule {
     private static final String TAG = "EndChanModule";
     
@@ -175,7 +180,7 @@ public class EndChanModule extends AbstractLynxChanModule {
     @Override
     public BoardModel getBoard(String shortName, ProgressListener listener, CancellableTask task) throws Exception {
         BoardModel model = super.getBoard(shortName, listener, task);
-        model.allowRandomHash = false;
+        model.allowRandomHash = false; // doesn't implemented
         return model;
     }
 
@@ -379,7 +384,6 @@ public class EndChanModule extends AbstractLynxChanModule {
         jsonPayload.put("captchaId", lastCaptchaId);
         jsonParameters.put("reason", model.reportReason);
         jsonParameters.put("captcha", lastCaptchaAnswer);
-        //jsonParameters.put("global", false);
         JSONArray jsonArray = new JSONArray();
         JSONObject post = new JSONObject();
         post.put("board", model.boardName);

--- a/src/nya/miku/wishmaster/chans/endchan/EndChanModule.java
+++ b/src/nya/miku/wishmaster/chans/endchan/EndChanModule.java
@@ -207,7 +207,7 @@ public class EndChanModule extends AbstractLynxChanModule {
         httpClient.getCookieStore().addCookie(c);
 
         ExtendedCaptchaModel captchaModel = super.getNewCaptcha(boardName, threadNumber, listener, task);
-        lastCaptchaId = captchaModel.captchaID;
+        if (captchaModel != null) lastCaptchaId = captchaModel.captchaID;
         return captchaModel;
     }
 
@@ -235,7 +235,7 @@ public class EndChanModule extends AbstractLynxChanModule {
 
     public String sendPost(SendPostModel model, ProgressListener listener, CancellableTask task) throws Exception {
         boolean captchaSolved = false;
-        if (model.captchaAnswer != null) {
+        if (model.captchaAnswer != null && model.captchaAnswer.length() > 0) {
             captchaSolved = validateCaptcha(model.captchaAnswer, listener, task);
         } else if (lastCaptchaId == null) {
             getNewCaptcha(null, null, listener, task);

--- a/src/nya/miku/wishmaster/chans/endchan/EndChanModule.java
+++ b/src/nya/miku/wishmaster/chans/endchan/EndChanModule.java
@@ -36,6 +36,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import cz.msebera.android.httpclient.impl.cookie.BasicClientCookie;
 import nya.miku.wishmaster.R;
@@ -44,8 +45,10 @@ import nya.miku.wishmaster.api.interfaces.CancellableTask;
 import nya.miku.wishmaster.api.interfaces.ProgressListener;
 import nya.miku.wishmaster.api.models.BoardModel;
 import nya.miku.wishmaster.api.models.DeletePostModel;
+import nya.miku.wishmaster.api.models.PostModel;
 import nya.miku.wishmaster.api.models.SendPostModel;
 import nya.miku.wishmaster.api.models.UrlPageModel;
+import nya.miku.wishmaster.api.util.RegexUtils;
 import nya.miku.wishmaster.common.IOUtils;
 import nya.miku.wishmaster.common.Logger;
 import nya.miku.wishmaster.http.JSONEntry;
@@ -60,15 +63,17 @@ import nya.miku.wishmaster.lib.org_json.JSONException;
 import nya.miku.wishmaster.lib.org_json.JSONObject;
 
 public class EndChanModule extends AbstractLynxChanModule {
-    private static final List<String> DOMAINS_LIST = Arrays.asList(new String[]{
-            "endchan.xyz", "endchan.net", "infinow.net", "endchan5doxvprs5.onion", "s6424n4x4bsmqs27.onion", "endchan.i2p"
-    });
-    private static final String DOMAINS_HINT = "endchan.xyz, endchan.net, infinow.net (cached), endchan5doxvprs5.onion, s6424n4x4bsmqs27.onion, endchan.i2p";
     private static final String TAG = "EndChanModule";
-    private static final String DISPLAYING_NAME = "EndChan";
+    
+    private static final List<String> DOMAINS_LIST = Arrays.asList(
+            "endchan.xyz", "endchan.net", "endchan.org", "endchan5doxvprs5.onion", "s6424n4x4bsmqs27.onion", "endchan.i2p");
+    private static final String DOMAINS_HINT = "endchan.xyz, endchan.net, endchan.org (cached), endchan5doxvprs5.onion, s6424n4x4bsmqs27.onion, endchan.i2p";
+    private static final String DISPLAYING_NAME = "Endchan";
     private static final String CHAN_NAME = "endchan.xyz";
     private static final String DEFAULT_DOMAIN = "endchan.xyz";
     private static final String PREF_KEY_DOMAIN = "domain";
+    private static final Pattern EMBED_HREF_PATTERN = Pattern.compile("<span class=\"youtube_wrapper\".*?<a href=\"([^\"]+)\".*?</span>");
+    
     private String domain;
     
     private String lastCaptchaId;
@@ -171,6 +176,13 @@ public class EndChanModule extends AbstractLynxChanModule {
     public BoardModel getBoard(String shortName, ProgressListener listener, CancellableTask task) throws Exception {
         BoardModel model = super.getBoard(shortName, listener, task);
         model.allowRandomHash = false;
+        return model;
+    }
+
+    @Override
+    protected PostModel mapPostModel(JSONObject object) {
+        PostModel model = super.mapPostModel(object);
+        model.comment = RegexUtils.replaceAll(model.comment, EMBED_HREF_PATTERN, "<a href=\"$1\">$1</a>");
         return model;
     }
 

--- a/src/nya/miku/wishmaster/chans/endchan/EndChanModule.java
+++ b/src/nya/miku/wishmaster/chans/endchan/EndChanModule.java
@@ -29,11 +29,29 @@ import android.preference.PreferenceGroup;
 import android.support.v4.content.res.ResourcesCompat;
 import android.text.InputType;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
 import nya.miku.wishmaster.R;
 import nya.miku.wishmaster.api.AbstractLynxChanModule;
+import nya.miku.wishmaster.api.interfaces.CancellableTask;
+import nya.miku.wishmaster.api.interfaces.ProgressListener;
+import nya.miku.wishmaster.api.models.DeletePostModel;
+import nya.miku.wishmaster.api.models.SendPostModel;
+import nya.miku.wishmaster.api.models.UrlPageModel;
+import nya.miku.wishmaster.common.IOUtils;
+import nya.miku.wishmaster.http.JSONEntry;
+import nya.miku.wishmaster.http.streamer.HttpRequestModel;
+import nya.miku.wishmaster.http.streamer.HttpStreamer;
+import nya.miku.wishmaster.lib.MimeTypes;
+import nya.miku.wishmaster.lib.base64.Base64;
+import nya.miku.wishmaster.lib.base64.Base64OutputStream;
+import nya.miku.wishmaster.lib.org_json.JSONArray;
+import nya.miku.wishmaster.lib.org_json.JSONObject;
 
 public class EndChanModule extends AbstractLynxChanModule {
     private static final List<String> DOMAINS_LIST = Arrays.asList(new String[]{
@@ -46,6 +64,9 @@ public class EndChanModule extends AbstractLynxChanModule {
     private static final String DEFAULT_DOMAIN = "endchan.xyz";
     private static final String PREF_KEY_DOMAIN = "domain";
     private String domain;
+    
+    private String lastCaptchaId;
+    private String lastCaptchaAnswer;
 
     public EndChanModule(SharedPreferences preferences, Resources resources) {
         super(preferences, resources);
@@ -139,4 +160,151 @@ public class EndChanModule extends AbstractLynxChanModule {
     public Drawable getChanFavicon() {
         return ResourcesCompat.getDrawable(resources, R.drawable.favicon_endchan, null);
     }
+
+
+    private String checkFileIdentifier(File file, String mime, ProgressListener listener, CancellableTask task) {
+        String hash;
+        try {
+            hash = computeFileMD5(file);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+        String identifier = hash + "-" + mime.replace("/", "");
+        String url = getUsingUrl() + "checkFileIdentifier.js?identifier=" + identifier;
+        String response = "";
+        try {
+            response = HttpStreamer.getInstance().getStringFromUrl(url, null, httpClient, listener, task, false);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+        if (response.contains("true")) return hash;
+        return null;
+    }
+
+    private String base64EncodeFile(File file) throws IOException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        Base64OutputStream b64os = new Base64OutputStream(os, Base64.NO_WRAP);
+        FileInputStream fis = new FileInputStream(file);
+        IOUtils.copyStream(fis, b64os);
+        return os.toString();
+    }
+
+    public String sendPost(SendPostModel model, ProgressListener listener, CancellableTask task) throws Exception {
+        String url = getUsingUrl() + ".api/" + (model.threadNumber == null ? "newThread" : "replyThread");
+
+        JSONObject jsonPayload = new JSONObject();
+        JSONObject jsonParameters = new JSONObject();
+        jsonPayload.put("captchaId", lastCaptchaId);
+        jsonParameters.put("name", model.name);
+        jsonParameters.put("password", model.password);
+        jsonParameters.put("subject", model.subject);
+        jsonParameters.put("message", model.comment);
+        jsonParameters.put("boardUri", model.boardName);
+        jsonParameters.put("email", model.sage ? "sage" : model.email);
+        if (model.threadNumber != null)
+            jsonParameters.put("threadId", model.threadNumber);
+        if (model.captchaAnswer != null && model.captchaAnswer.length() > 0)
+            jsonParameters.put("captcha", model.captchaAnswer);
+        if (model.icon > 0)
+            jsonParameters.put("flag", flagsMap.get(model.boardName).get(model.icon - 1));
+        if (model.attachments != null && model.attachments.length > 0) {
+            JSONArray files = new JSONArray();
+            for (int i = 0; i < model.attachments.length; ++i) {
+                String name = model.attachments[i].getName();
+                String mime = MimeTypes.forExtension(name.substring(name.lastIndexOf('.') + 1), "");
+                String md5 = checkFileIdentifier(model.attachments[i], mime, listener, task);
+                JSONObject file = new JSONObject();
+                file.put("name", name);
+                if (md5 != null) {
+                    file.put("md5", md5);
+                    file.put("mime", mime);
+                } else {
+                    file.put("content", "data:" + mime + ";base64," + base64EncodeFile(model.attachments[i]));
+                }
+                file.put("spoiler", false);
+                files.put(file);
+            }
+            jsonParameters.put("spoiler", model.custommark);
+            jsonParameters.put("files", files);
+        }
+        jsonPayload.put("parameters", jsonParameters);
+        JSONEntry payload = new JSONEntry(jsonPayload);
+        HttpRequestModel request = HttpRequestModel.builder().setPOST(payload).setNoRedirect(true).build();
+        String response = HttpStreamer.getInstance().getStringFromUrl(url, request, httpClient, null, task, true);
+        lastCaptchaId = null;
+        JSONObject result = new JSONObject(response);
+        String status = result.optString("status");
+        if ("ok".equals(status)) {
+            UrlPageModel urlPageModel = new UrlPageModel();
+            urlPageModel.type = UrlPageModel.TYPE_THREADPAGE;
+            urlPageModel.chanName = getChanName();
+            urlPageModel.boardName = model.boardName;
+            urlPageModel.threadNumber = model.threadNumber;
+            if (model.threadNumber == null) {
+                urlPageModel.threadNumber = Integer.toString(result.optInt("data"));
+            } else {
+                urlPageModel.postNumber = Integer.toString(result.optInt("data"));
+            }
+            return buildUrl(urlPageModel);
+        } else if (status.contains("error") || status.contains("blank")) {
+            String errorMessage = result.optString("data");
+            if (errorMessage.length() > 0) {
+                throw new Exception(errorMessage);
+            }
+        }
+        throw new Exception("Unknown Error");
+    }
+
+    @Override
+    public String deletePost(DeletePostModel model, final ProgressListener listener, final CancellableTask task) throws Exception {
+        String url = getUsingUrl() + ".api/" + "deleteContent";
+        /*
+        if (lastCaptchaAnswer == null) {
+            throw new SimpleCaptchaException() {
+                private static final long serialVersionUID = 1L;
+                @Override
+                protected Bitmap getNewCaptcha() throws Exception {
+                    return AbstractLynxChanModule.this.getNewCaptcha("", "", listener, task).bitmap;
+                }
+                @Override
+                protected void storeResponse(String response) {
+                    lastCaptchaAnswer = response;
+                }
+            };
+        }
+        */
+        JSONObject jsonPayload = new JSONObject();
+        JSONObject jsonParameters = new JSONObject();
+        jsonPayload.put("captchaId", lastCaptchaId);
+        jsonParameters.put("password", model.password);
+        if (lastCaptchaAnswer != null && lastCaptchaAnswer.length() > 0)
+            jsonParameters.put("captcha", lastCaptchaAnswer);
+        jsonParameters.put("deleteMedia", true);
+        if (model.onlyFiles) {
+            jsonParameters.put("deleteUploads", true);
+        }
+        JSONArray jsonArray = new JSONArray();
+        JSONObject post = new JSONObject();
+        post.put("board", model.boardName);
+        post.put("thread", model.threadNumber);
+        if (!model.postNumber.equals(model.threadNumber)) post.put("post", model.postNumber);
+        jsonParameters.put("postings", jsonArray);
+        jsonPayload.put("parameters", jsonParameters);
+        JSONEntry payload = new JSONEntry(jsonPayload);
+        HttpRequestModel request = HttpRequestModel.builder().setPOST(payload).setNoRedirect(true).build();
+        String response = HttpStreamer.getInstance().getStringFromUrl(url, request, httpClient, null, task, true);
+        lastCaptchaId = null;
+        lastCaptchaAnswer = null;
+        JSONObject result = new JSONObject(response);
+        if (result.optString("status").equals("error")) {
+            String errorMessage = result.optString("data");
+            if (errorMessage.length() > 0) {
+                throw new Exception(errorMessage);
+            }
+        }
+        return null;
+    }
+
 }

--- a/src/nya/miku/wishmaster/chans/kohlchan/KohlchanCaptchaException.java
+++ b/src/nya/miku/wishmaster/chans/kohlchan/KohlchanCaptchaException.java
@@ -1,0 +1,37 @@
+package nya.miku.wishmaster.chans.kohlchan;
+
+import android.graphics.Bitmap;
+
+import nya.miku.wishmaster.api.AbstractLynxChanModule;
+import nya.miku.wishmaster.api.interfaces.CancellableTask;
+import nya.miku.wishmaster.common.MainApplication;
+import nya.miku.wishmaster.http.interactive.SimpleCaptchaException;
+
+public class KohlchanCaptchaException extends SimpleCaptchaException {
+    private static final long serialVersionUID = 1L;
+
+    private String captchaId = "";
+
+    protected Bitmap getNewCaptcha() throws Exception {
+        AbstractLynxChanModule.ExtendedCaptchaModel captcha =
+                ((KohlchanModule) MainApplication.getInstance()
+                        .getChanModule(KohlchanModule.CHAN_NAME))
+                        .getNewCaptcha(null, null, null, new CancellableTask() {
+                            @Override
+                            public void cancel() {
+                            }
+
+                            @Override
+                            public boolean isCancelled() {
+                                return false;
+                            }
+                        });
+        captchaId = captcha.captchaID;
+        return captcha.bitmap;
+    }
+
+    protected void storeResponse(String response) {
+        ((KohlchanModule) MainApplication.getInstance().getChanModule(KohlchanModule.CHAN_NAME))
+                .putCaptcha(captchaId, response);
+    }
+}

--- a/src/nya/miku/wishmaster/chans/kohlchan/KohlchanCaptchaException.java
+++ b/src/nya/miku/wishmaster/chans/kohlchan/KohlchanCaptchaException.java
@@ -1,3 +1,21 @@
+/*
+ * Overchan Android (Meta Imageboard Client)
+ * Copyright (C) 2014-2016  miku-nyan <https://github.com/miku-nyan>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package nya.miku.wishmaster.chans.kohlchan;
 
 import android.graphics.Bitmap;

--- a/src/nya/miku/wishmaster/chans/kohlchan/KohlchanModule.java
+++ b/src/nya/miku/wishmaster/chans/kohlchan/KohlchanModule.java
@@ -29,23 +29,30 @@ import android.support.v4.content.res.ResourcesCompat;
 import android.text.InputType;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
+import cz.msebera.android.httpclient.impl.cookie.BasicClientCookie;
 import nya.miku.wishmaster.R;
 import nya.miku.wishmaster.api.AbstractLynxChanModule;
 import nya.miku.wishmaster.api.interfaces.CancellableTask;
 import nya.miku.wishmaster.api.interfaces.ProgressListener;
 import nya.miku.wishmaster.api.models.BoardModel;
+import nya.miku.wishmaster.api.models.SendPostModel;
 import nya.miku.wishmaster.api.models.SimpleBoardModel;
+import nya.miku.wishmaster.api.models.UrlPageModel;
 import nya.miku.wishmaster.common.IOUtils;
-import nya.miku.wishmaster.common.Logger;
+import nya.miku.wishmaster.http.ExtendedMultipartBuilder;
 import nya.miku.wishmaster.http.streamer.HttpRequestModel;
 import nya.miku.wishmaster.http.streamer.HttpResponseModel;
 import nya.miku.wishmaster.http.streamer.HttpStreamer;
 import nya.miku.wishmaster.http.streamer.HttpWrongStatusCodeException;
+import nya.miku.wishmaster.lib.MimeTypes;
+import nya.miku.wishmaster.lib.org_json.JSONObject;
 
 public class KohlchanModule extends AbstractLynxChanModule {
     private static final String TAG = "KohlchanModule";
@@ -63,6 +70,7 @@ public class KohlchanModule extends AbstractLynxChanModule {
             "jpg", "jpeg", "bmp", "gif", "png", "mp3", "ogg", "flac", "opus", "webm", "mp4", "7z", "zip", "pdf", "epub", "txt" };
     
     private String domain;
+    private Map<String, String> captchas = new HashMap<>();
 
     public KohlchanModule(SharedPreferences preferences, Resources resources) {
         super(preferences, resources);
@@ -76,6 +84,10 @@ public class KohlchanModule extends AbstractLynxChanModule {
     @Override
     protected void initHttpClient() {
         updateDomain(preferences.getString(getSharedKey(PREF_KEY_DOMAIN), DEFAULT_DOMAIN));
+        BasicClientCookie cookieConsent = new BasicClientCookie("cookieConsent", "true");
+        cookieConsent.setDomain(getUsingDomain());
+        cookieConsent.setPath("/");
+        httpClient.getCookieStore().addCookie(cookieConsent);
     }
 
     @Override
@@ -189,23 +201,123 @@ public class KohlchanModule extends AbstractLynxChanModule {
     }
 
     @Override
-    protected Map<String, SimpleBoardModel> getBoardsMap(ProgressListener listener, CancellableTask task) throws Exception {
-        try {
-            return super.getBoardsMap(listener, task);
-        } catch (Exception e) {
-            Logger.e(TAG, e);
-            return Collections.emptyMap();
-        }
-    }
-    
-    @Override
     public BoardModel getBoard(String shortName, ProgressListener listener, CancellableTask task) throws Exception {
         BoardModel model = super.getBoard(shortName, listener, task);
         model.defaultUserName = "Bernd";
-        model.attachmentsMaxCount = 4;
-        model.allowNames = false;
         model.allowEmails = false;
         model.attachmentsFormatFilters = ATTACHMENT_FORMATS;
         return model;
+    }
+
+    void putCaptcha(String captchaID, String answer) {
+        if (captchas == null) captchas = new HashMap<>();
+        captchas.put(captchaID, answer);
+    }
+
+    private void validateCaptcha(String captchaID, ProgressListener listener, CancellableTask task) throws Exception {
+        String captchaAnswer = captchas.remove(captchaID);
+        if (captchaAnswer == null) captchaAnswer = "";
+        String url = getUsingUrl() + "renewBypass.js?json=1";
+        ExtendedMultipartBuilder postEntityBuilder = ExtendedMultipartBuilder.create().setDelegates(listener, task).
+                addString("captcha", captchaAnswer);
+        HttpRequestModel request = HttpRequestModel.builder().setPOST(postEntityBuilder.build()).build();
+        JSONObject response;
+        try {
+            response = HttpStreamer.getInstance().getJSONObjectFromUrl(url, request, httpClient, listener, task, true);
+        } catch (HttpWrongStatusCodeException e) {
+            checkCloudflareError(e, url);
+            throw e;
+        }
+        switch (response.optString("status")) {
+            case "failed":
+            case "new":
+            case "next":
+                throw new KohlchanCaptchaException();
+            case "finish":
+                return;
+            case "error":
+                throw new Exception(response.optString("data", "Captcha Error"));
+            default: throw new Exception("Unknown Error");
+        }
+    }
+
+    public String sendPost(SendPostModel model, ProgressListener listener, CancellableTask task) throws Exception {
+        String captchaId;
+        try {
+            captchaId = captchas.keySet().iterator().next();
+        } catch (NoSuchElementException e) {
+            captchaId = null;
+        }
+        if (captchaId != null) validateCaptcha(captchaId, listener, task);
+        
+        String url = getUsingUrl() + (model.threadNumber == null ? "newThread.js?json=1" : "replyThread.js?json=1");
+        
+        if (model.password.length() > MAX_PASSWORD_LENGTH) {
+            model.password = model.password.substring(0, MAX_PASSWORD_LENGTH);
+        }
+        ExtendedMultipartBuilder postEntityBuilder = ExtendedMultipartBuilder.create().setDelegates(listener, task).
+                setCharset(Charset.forName("UTF-8")).
+                addString("name", model.name).
+                addString("subject", model.subject).
+                addString("message", model.comment).
+                addString("password", model.password).
+                addString("boardUri", model.boardName);
+        if (model.sage) postEntityBuilder.addString("sage", "true");
+        if (model.threadNumber != null) postEntityBuilder.addString("threadId", model.threadNumber);
+        if (model.custommark) postEntityBuilder.addString("spoiler", "true");
+        if (model.attachments != null && model.attachments.length > 0) {
+            for (int i = 0; i < model.attachments.length; ++i) {
+                String name = model.attachments[i].getName();
+                String mime = MimeTypes.forExtension(name.substring(name.lastIndexOf('.') + 1));
+                if (mime == null) throw new Exception("Unknown file type of " + name);
+                String md5;
+                try {
+                    md5 = computeFileMD5(model.attachments[i]);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    throw new Exception("Cannot attach file " + name);
+                }
+                postEntityBuilder.
+                        addString("fileMd5", md5).
+                        addString("fileMime", mime).
+                        addString("fileSpoiler", "").
+                        addString("fileName", name);
+                boolean fileExists = checkFileIdentifier(md5, mime, listener, task);
+                if (!fileExists) {
+                    postEntityBuilder.addFile("files", model.attachments[i], mime, model.randomHash);
+                }
+            }
+        }
+        HttpRequestModel request = HttpRequestModel.builder().setPOST(postEntityBuilder.build()).setNoRedirect(true).build();
+        String response = HttpStreamer.getInstance().getStringFromUrl(url, request, httpClient, null, task, true);
+        JSONObject result = new JSONObject(response);
+        String status = result.optString("status");
+        if ("ok".equals(status)) {
+            UrlPageModel urlPageModel = new UrlPageModel();
+            urlPageModel.type = UrlPageModel.TYPE_THREADPAGE;
+            urlPageModel.chanName = getChanName();
+            urlPageModel.boardName = model.boardName;
+            urlPageModel.threadNumber = model.threadNumber;
+            if (model.threadNumber == null) {
+                urlPageModel.threadNumber = Integer.toString(result.optInt("data"));
+            } else {
+                urlPageModel.postNumber = Integer.toString(result.optInt("data"));
+            }
+            return buildUrl(urlPageModel);
+        } else if (status.contains("error") || status.contains("blank")) {
+            String errorMessage = result.optString("data");
+            if (errorMessage.length() > 0) {
+                throw new Exception(errorMessage);
+            }
+        } else if ("bypassable".equals(status)) {
+            throw new KohlchanCaptchaException();
+        } else if("banned".equals(status)) {
+            String banMessage = "You have been banned!";
+            try {
+                banMessage += "\nReason: " + result.getJSONObject("data").getString("reason");
+            } catch (Exception e) { }
+            throw new Exception(banMessage);
+        }
+        throw new Exception("Unknown Error");
     }
 }

--- a/src/nya/miku/wishmaster/chans/kohlchan/KohlchanModule.java
+++ b/src/nya/miku/wishmaster/chans/kohlchan/KohlchanModule.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.regex.Pattern;
 
 import cz.msebera.android.httpclient.impl.cookie.BasicClientCookie;
 import nya.miku.wishmaster.R;
@@ -43,9 +44,11 @@ import nya.miku.wishmaster.api.interfaces.CancellableTask;
 import nya.miku.wishmaster.api.interfaces.ProgressListener;
 import nya.miku.wishmaster.api.models.BoardModel;
 import nya.miku.wishmaster.api.models.DeletePostModel;
+import nya.miku.wishmaster.api.models.PostModel;
 import nya.miku.wishmaster.api.models.SendPostModel;
 import nya.miku.wishmaster.api.models.SimpleBoardModel;
 import nya.miku.wishmaster.api.models.UrlPageModel;
+import nya.miku.wishmaster.api.util.RegexUtils;
 import nya.miku.wishmaster.common.IOUtils;
 import nya.miku.wishmaster.common.Logger;
 import nya.miku.wishmaster.http.ExtendedMultipartBuilder;
@@ -64,13 +67,15 @@ public class KohlchanModule extends AbstractLynxChanModule {
     private static final String DISPLAYING_NAME = "Kohlchan";
     private static final String DEFAULT_DOMAIN = "kohlchan.net";
     private static final String PREF_KEY_DOMAIN = "domain";
-    private static final List<String> DOMAINS_LIST = Arrays.asList(new String[] {
-            DEFAULT_DOMAIN, "kohlchan.mett.ru", "kohlchankxguym67.onion", "fastkohlp6h2seef.onion"
-    });
-    private static final String DOMAINS_HINT = "kohlchan.net, kohlchan.mett.ru, kohlchankxguym67.onion, fastkohlp6h2seef.onion (1 hop)";
+    private static final List<String> DOMAINS_LIST = Arrays.asList(
+            DEFAULT_DOMAIN, "kohlchan.mett.ru", "kohlchankxguym67.onion", "fastkohlp6h2seef.onion",
+            "kohlchan7cwtdwfuicqhxgqx4k47bsvlt2wn5eduzovntrzvonv4cqyd.onion",
+            "fastkohlt5rxcxtl5no7k3efmahlt7mafry7be6yvxdovekhq2hdnwqd.onion");
+    private static final String DOMAINS_HINT = "kohlchan.net, kohlchan.mett.ru, kohlchankxguym67.onion, fastkohlp6h2seef.onion";
     
     private static final String[] ATTACHMENT_FORMATS = new String[] {
             "jpg", "jpeg", "bmp", "gif", "png", "mp3", "ogg", "flac", "opus", "webm", "mp4", "7z", "zip", "pdf", "epub", "txt" };
+    private static final Pattern INVALID_LESSER_THAN_PATTERN = Pattern.compile("&lt([^;])");
     
     private String domain;
     private Map<String, String> captchas = new HashMap<>();
@@ -210,6 +215,13 @@ public class KohlchanModule extends AbstractLynxChanModule {
         model.defaultUserName = "Bernd";
         model.allowEmails = false;
         model.attachmentsFormatFilters = ATTACHMENT_FORMATS;
+        return model;
+    }
+
+    @Override
+    protected PostModel mapPostModel(JSONObject object) {
+        PostModel model = super.mapPostModel(object);
+        model.comment = RegexUtils.replaceAll(model.comment, INVALID_LESSER_THAN_PATTERN, "&lt;$1");
         return model;
     }
 

--- a/src/nya/miku/wishmaster/http/ExtendedMultipartBuilder.java
+++ b/src/nya/miku/wishmaster/http/ExtendedMultipartBuilder.java
@@ -87,8 +87,9 @@ public class ExtendedMultipartBuilder {
         return addPart(key, new StringBody(value, ContentType.create("text/plain", "UTF-8")));
     }
     
-    private ExtendedMultipartBuilder addFile(String key, File value, final int randomTail) {
-        return addPart(key, new FileBody(value) {
+    private ExtendedMultipartBuilder addFile(String key, File value, String mimeType, final int randomTail) {
+        return addPart(key, (mimeType == null || mimeType.length() == 0) ? new FileBody(value)
+                : new FileBody(value, ContentType.create(mimeType), value.getName()) {
             @Override
             public long getContentLength() {
                 return super.getContentLength() + randomTail;
@@ -109,11 +110,23 @@ public class ExtendedMultipartBuilder {
      * Добавить файл
      * @param key имя (ключ)
      * @param file прикрепляемый файл
+     * @param mimeType тип прикрепляемого файла
+     * @param uniqueHash если true, добавит в конец файла несколько рандомных байтов, чтобы создать уникальный хэш
+     * @return этот объект
+     */
+    public ExtendedMultipartBuilder addFile(String key, File file, String mimeType, boolean uniqueHash) {
+        return addFile(key, file, mimeType, uniqueHash ? RANDOMHASH_TAIL_SIZE : 0);
+    }
+
+    /**
+     * Добавить файл
+     * @param key имя (ключ)
+     * @param file прикрепляемый файл
      * @param uniqueHash если true, добавит в конец файла несколько рандомных байтов, чтобы создать уникальный хэш
      * @return этот объект
      */
     public ExtendedMultipartBuilder addFile(String key, File file, boolean uniqueHash) {
-        return addFile(key, file, uniqueHash ? RANDOMHASH_TAIL_SIZE : 0);
+        return addFile(key, file, null, uniqueHash ? RANDOMHASH_TAIL_SIZE : 0);
     }
     
     /**

--- a/src/nya/miku/wishmaster/http/ExtendedMultipartBuilder.java
+++ b/src/nya/miku/wishmaster/http/ExtendedMultipartBuilder.java
@@ -88,8 +88,8 @@ public class ExtendedMultipartBuilder {
     }
     
     private ExtendedMultipartBuilder addFile(String key, File value, String mimeType, final int randomTail) {
-        return addPart(key, (mimeType == null || mimeType.length() == 0) ? new FileBody(value)
-                : new FileBody(value, ContentType.create(mimeType), value.getName()) {
+        return addPart(key, new FileBody(value, (mimeType == null || mimeType.length() == 0) ?
+                ContentType.APPLICATION_OCTET_STREAM : ContentType.create(mimeType)) {
             @Override
             public long getContentLength() {
                 return super.getContentLength() + randomTail;

--- a/src/nya/miku/wishmaster/lib/MimeTypes.java
+++ b/src/nya/miku/wishmaster/lib/MimeTypes.java
@@ -1,0 +1,94 @@
+package nya.miku.wishmaster.lib;
+
+import android.webkit.MimeTypeMap;
+
+import java.util.HashMap;
+import java.util.Locale;
+
+/**
+ * Workaround for MimeTypeMap.
+ * Contains mime types of most popular file formats.
+ * Handles them even if the internal implementation fails.
+ * @author Fukurou Mishiranu
+ */
+public class MimeTypes {
+
+    private static final HashMap<String, String> MIME_TYPE_MAP = new HashMap<>();
+    private static final HashMap<String, String> EXTENSION_MAP = new HashMap<>();
+    static {
+        addMime("epub", "application/epub+zip");
+        addMime("ogg", "application/ogg");
+        addMime("pdf", "application/pdf");
+        addMime("apk", "application/vnd.android.package-archive");
+        addMime("xhtml", "application/xhtml+xml");
+        addMime("7z", "application/x-7z-compressed");
+        addMime("swf", "application/x-shockwave-flash");
+        addMime("tar", "application/x-tar");
+        addMime("zip", "application/zip");
+        addMime("aac", "audio/aac");
+        addMime("flac", "audio/flac");
+        addMime("midi", "audio/midi");
+        addMime("mid", "audio/midi");
+        addMime("mp3", "audio/mpeg");
+        addMime("opus", "audio/opus");
+        addMime("wav", "audio/x-wav");
+        addMime("gif", "image/gif");
+        addMime("jpe", "image/jpeg");
+        addMime("jpeg", "image/jpeg");
+        addMime("jpg", "image/jpeg");
+        addMime("apng", "image/png");
+        addMime("png", "image/png");
+        addMime("svgz", "image/svg+xml");
+        addMime("svg", "image/svg+xml");
+        addMime("webp", "image/webp");
+        addMime("ico", "image/x-icon");
+        addMime("bmp", "image/x-ms-bmp");
+        addMime("css", "text/css");
+        addMime("html", "text/html");
+        addMime("htm", "text/html");
+        addMime("txt", "text/plain");
+        addMime("xml", "text/xml");
+        addMime("mp4", "video/mp4");
+        addMime("webm", "video/webm");
+    }
+    
+    public static String forExtension(String extension, String defaultMimeType) {
+        if (extension != null && extension.length() != 0) {
+            extension = extension.toLowerCase(Locale.US);
+            String mimeType = MIME_TYPE_MAP.get(extension);
+            if (mimeType == null) {
+                mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+            }
+            if (mimeType != null) {
+                return mimeType;
+            }
+        }
+        return defaultMimeType;
+    }
+
+    public static String forExtension(String extension) {
+        return forExtension(extension, null);
+    }
+
+    public static String toExtension(String mimeType, String defaultExtension) {
+        if (mimeType != null && mimeType.length() != 0) {
+            String extension = EXTENSION_MAP.get(mimeType);
+            if (extension == null) {
+                extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
+            }
+            if (extension != null) {
+                return extension;
+            }
+        }
+        return defaultExtension;
+    }
+
+    public static String toExtension(String mimeType) {
+        return toExtension(mimeType, null);
+    }
+
+    private static void addMime(String extension, String mimeType) {
+        MIME_TYPE_MAP.put(extension, mimeType);
+        EXTENSION_MAP.put(mimeType, extension);
+    }
+}


### PR DESCRIPTION
Added:
- support for Lynxchan API v2 in Kohlchan (send, delete and report posts)
- reports function in Endchan
- external MIME types library to fix Android WebKit's lib
- interactive captcha (download only if required by board settings)

Fixed:
- posting and deletion in Endchan
- open original files in catalog
- several issues in posts markup (linkified URLs, YouTube links, incorrect symbols)

Not fixed:
- posting to Endchan from Tor ('bypassable' error)